### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM python:3.10-alpine as build
 WORKDIR /tmp
+ARG REVISION=master
 RUN set -eux; \
-      wget https://github.com/frozenpandaman/s3s/archive/refs/heads/master.zip -O s3s.zip && \
-      unzip s3s.zip && rm s3s.zip && mv s3s* /opt/s3s
+    wget "https://github.com/frozenpandaman/s3s/archive/${REVISION}.zip" -O s3s.zip && \
+    unzip s3s.zip && rm s3s.zip && mv s3s* /opt/s3s
 WORKDIR /opt/s3s
 RUN set -eux; \
-      pip install -r requirements.txt
+    echo "$REVISION" > REVISION
+RUN set -eux; \
+    pip install -r requirements.txt
 # Cleanup
 RUN set -eux; \
-      rm -fr .github .gitignore requirements.txt
+    rm -fr .github .gitignore requirements.txt
 
 FROM python:3.10-alpine
 LABEL maintainer="issei-m (https://twitter.com/Issei_M)"
@@ -17,7 +20,7 @@ COPY --from=build /usr/local/lib/python3.10/site-packages /usr/local/lib/python3
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY --from=build /opt/s3s /opt/s3s
 RUN set -eux; \
-      chown -R s3s.s3s /opt/s3s
+    chown -R s3s.s3s /opt/s3s
 WORKDIR /opt/s3s
 USER s3s
 ENTRYPOINT ["/entrypoint.sh", "python", "/opt/s3s/s3s.py"]


### PR DESCRIPTION
Now can specify revision (commit hash, tag, branch) to reference the version of s3s in `REVISION` build arg

example:

```
# Specify nothing (master reference at this point is used)
docker build -t s3s .

# Specify commit hash
docker build -t s3s --build-arg REVISION=c6e9694 .

# Specify tag
docker build -t s3s --build-arg REVISION=v1.0.0 .
```

And the value is dumped to /opt/s3s/REVISION