### PR TITLE
[experimental] s3s.py `check_for_updates` is now bypassed because it is not necessary in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM python:3.10-alpine as build
+RUN set -eux; \
+    apk --no-cache upgrade && \
+    apk add --no-cache patch
 WORKDIR /tmp
+COPY bypassing_update_check.patch /tmp
 ARG REVISION=master
 RUN set -eux; \
     wget "https://github.com/frozenpandaman/s3s/archive/${REVISION}.zip" -O s3s.zip && \
     unzip s3s.zip && rm s3s.zip && mv s3s* /opt/s3s
 WORKDIR /opt/s3s
+RUN set -eux; \
+    patch -u s3s.py -i /tmp/bypassing_update_check.patch
 RUN set -eux; \
     echo "$REVISION" > REVISION
 RUN set -eux; \

--- a/bypassing_update_check.patch
+++ b/bypassing_update_check.patch
@@ -1,0 +1,11 @@
+--- a.py	2022-12-05 18:31:34.000000000 +0900
++++ b.py	2022-12-05 18:32:23.000000000 +0900
+@@ -1667,7 +1667,7 @@
+ 
+ 	# setup
+ 	#######
+-	check_for_updates()
++	# check_for_updates() # Bypassed this because this isn't necessary when the program runs on the container.
+ 	check_statink_key()
+ 	set_language()
+ 


### PR DESCRIPTION
https://github.com/frozenpandaman/s3s/blob/3ea8061ddcc4f9fe08b9034982b05bc29aebd420/s3s.py#L1670