### PR TITLE
Bump up Python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine as build
+FROM python:3.12-alpine as build
 RUN set -eux; \
     apk --no-cache upgrade && \
     apk add --no-cache patch
@@ -19,10 +19,10 @@ RUN set -eux; \
 RUN set -eux; \
     rm -fr .github .gitignore requirements.txt
 
-FROM python:3.11-alpine
+FROM python:3.12-alpine
 LABEL maintainer="issei-m (https://twitter.com/Issei_M)"
 RUN addgroup -S -g 1000 s3s && adduser -S -G s3s -u 999 s3s
-COPY --from=build /root/.local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=build /root/.local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY --from=build /opt/s3s /opt/s3s
 RUN set -eux; \


### PR DESCRIPTION
3.12 is now RC. After GA, re-build images.